### PR TITLE
Minor fix to init.cmd: move xcopy to inside of correct directory

### DIFF
--- a/init.cmd
+++ b/init.cmd
@@ -36,7 +36,7 @@ cd tools
 call colcon build --merge-install --cmake-args -DBUILD_TESTING=OFF
 cd ..
 
-goto :eol
+goto :eof
 
 :novcpkg
 echo "VCPkg not found at c:\opt\vcpkg\vcpkg.exe"

--- a/init.cmd
+++ b/init.cmd
@@ -28,9 +28,9 @@ vcs import src < ..\build_tools.repos
 
 cd ..\target
 vcs import src < ..\ros2_uwp.repos
+xcopy /y src\ros2\orocos_kinematics_dynamics\orocos_kdl\config\FindEigen3.cmake src\ros2\eigen3_cmake_module\cmake\Modules
 cd ..
 
-xcopy /y src\ros2\orocos_kinematics_dynamics\orocos_kdl\config\FindEigen3.cmake src\ros2\eigen3_cmake_module\cmake\Modules
 
 cd tools
 call colcon build --merge-install --cmake-args -DBUILD_TESTING=OFF


### PR DESCRIPTION
the relative path for the xcopy command only makes sense when called from withing target